### PR TITLE
Fix typo in English locale

### DIFF
--- a/locales/en.js
+++ b/locales/en.js
@@ -42,7 +42,7 @@ export default {
     }
   },
   error: {
-    title: 'An Error Occured',
+    title: 'An Error Occurred',
     home: 'Back home',
     notFound: {
       text: 'Page not found'


### PR DESCRIPTION
## Summary
- correct spelling of error title in English locale

## Testing
- `npm run lint:sass` *(fails: stylelint not found)*

------
https://chatgpt.com/codex/tasks/task_e_686a057c34b08325baf5249ee6a97a5f