### PR TITLE
Gate newsletter modal on cookie-consent and clear timeout on destroy

### DIFF
--- a/components/NewsletterModal.vue
+++ b/components/NewsletterModal.vue
@@ -19,6 +19,9 @@
     created() {
       this.resetTimeout(); // Start the initial timeout
     },
+    beforeDestroy() {
+      clearTimeout(this.timeoutId);
+    },
     methods: {
       close() {
         this.$store.commit('SET_NEWSLETTER_OPENED', false);
@@ -34,7 +37,10 @@
         clearTimeout(this.timeoutId); // Clear the previous timeout (if any)
 
         this.timeoutId = setTimeout(() => {
-          if(!this.$cookies.get('labete_newsletter')) {
+          const hasNewsletterCookie = !!this.$cookies.get('labete_newsletter');
+          const hasCookieConsent = !!this.$cookies.get('labete_cookie_seen');
+
+          if (!hasNewsletterCookie && hasCookieConsent) {
             this.$store.commit('SET_NEWSLETTER_OPENED', true);
           }
           this.resetTimeout();


### PR DESCRIPTION
### Motivation
- Prevent the newsletter modal from opening when cookie-consent has already been given by ensuring the modal checks `labete_cookie_seen` before showing.
- Avoid stale timers running after the component unmounts by clearing the recurring timeout during teardown.

### Description
- Add a `beforeDestroy` hook that clears the component's `timeoutId` to stop the recurring timer when the component is torn down.
- Update `resetTimeout` to compute `hasNewsletterCookie = !!this.$cookies.get('labete_newsletter')` and `hasCookieConsent = !!this.$cookies.get('labete_cookie_seen')`, and only commit `SET_NEWSLETTER_OPENED` when `!hasNewsletterCookie && hasCookieConsent`.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe7fc818a08325807626787fec5368)